### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/configure-pages@v5.0.0
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.218.0
+        uses: ruby/setup-ruby@v1.220.0
         with:
           ruby-version: 3.2.2
           bundler-cache: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ruby/setup-ruby](https://github.com/ruby/setup-ruby)** published a new release **[v1.220.0](https://github.com/ruby/setup-ruby/releases/tag/v1.220.0)** on 2025-02-15T13:06:05Z
